### PR TITLE
Refactor Kafka Client.

### DIFF
--- a/src/main/scala/imgdetect/RunDetector.scala
+++ b/src/main/scala/imgdetect/RunDetector.scala
@@ -23,7 +23,7 @@ object RunDetector {
     val kafkaConsumer = new KafkaClient[DetectMessage](INTOPIC)
     val kafkaProducer = new KafkaClient[StoreDetectedMessage](OUTTOPIC)
 
-    kafkaConsumer.consumerStart()
+    //kafkaConsumer.consumerStart()
 
     while (true) {
       val msg = kafkaConsumer.receive()

--- a/src/main/scala/imgretrieve/RunRetriever.scala
+++ b/src/main/scala/imgretrieve/RunRetriever.scala
@@ -18,7 +18,7 @@ object RunRetriever {
     val kafkaConsumer = new KafkaClient[DownloadMessage](INTOPIC)
     val kafkaProducer = new KafkaClient[DetectMessage](OUTTOPIC)
 
-    kafkaConsumer.consumerStart()
+    //kafkaConsumer.consumerStart()
 
     while (true) {
       val msg = kafkaConsumer.receive()

--- a/src/main/scala/messages/KafkaPartitioner.scala
+++ b/src/main/scala/messages/KafkaPartitioner.scala
@@ -1,0 +1,14 @@
+package messages
+
+import kafka.producer.Partitioner
+import kafka.utils.VerifiableProperties
+
+class KafkaPartitioner(props: VerifiableProperties) extends Partitioner {
+  var roundRobinCounter = 0
+
+  def partition(key: Any, numPartitions: Int): Int = {
+    roundRobinCounter = (roundRobinCounter + 1) % numPartitions
+    roundRobinCounter
+  }
+}
+

--- a/src/main/scala/storage/RunStorage.scala
+++ b/src/main/scala/storage/RunStorage.scala
@@ -13,7 +13,7 @@ object RunStorage {
     val kafkaConsumer = new KafkaClient[StoreDetectedMessage](TOPIC)
     val db = MemDB
 
-    kafkaConsumer.consumerStart()
+    //kafkaConsumer.consumerStart()
 
     while (true) {
       val msg = kafkaConsumer.receive()


### PR DESCRIPTION
- KafkaClient no longer requires a consumerStart() call before using the
  consumer.
- KafkaClient no longer buffers any messages.
- KafkaClient producer now load balances partitions.
